### PR TITLE
Added alias for latest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author="Jan Holthuis",
     author_email="holthuis.jan@googlemail.com",
     url="https://holzhaus.github.io/sphinx-multiversion/",
-    version="0.2.8",
+    version="0.2.9",
     install_requires=["sphinx >= 2.1"],
     license="BSD",
     packages=["sphinx_multiversion"],

--- a/sphinx_multiversion/main.py
+++ b/sphinx_multiversion/main.py
@@ -268,8 +268,10 @@ def main(argv=None):
                 config=current_config,
             )
 
-            # Rename output dir
+            # Rename outputdir to latest version name
+            aliasdir = ''
             if config.smv_latest_version == gitref.name and config.smv_rename_latest_version:
+                aliasdir = outputdir
                 outputdir = config.smv_rename_latest_version
 
             if outputdir in outputdirs:
@@ -304,6 +306,9 @@ def main(argv=None):
                 "sourcedir": current_sourcedir,
                 "outputdir": os.path.join(
                     os.path.abspath(args.outputdir), outputdir
+                ),
+                "aliasdir": '' if not aliasdir else os.path.join(
+                    os.path.abspath(args.outputdir), aliasdir
                 ),
                 "confdir": confpath,
                 "docnames": list(project.discover()),
@@ -376,5 +381,11 @@ def main(argv=None):
                     except OSError as err:
                         logger.warning("Command '%s' failed for build '%s': '%s'", command, data["name"], err)
             subprocess.check_call(cmd, cwd=current_cwd, env=env)
+
+            # Create alias for latest version
+            if data['aliasdir']:
+                if os.path.exists(data['aliasdir']):
+                     os.remove(data['aliasdir'])
+                os.symlink(data['outputdir'], data['aliasdir'])
 
     return 0


### PR DESCRIPTION
Related issue: https://github.com/scylladb/scylla-operator/issues/350

The latest version URL can now be accessed either using the "rename_latest_version" setting or the original version name.